### PR TITLE
Add GET endpoint to read a recommendation by ID

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python-envs.defaultEnvManager": "ms-python.python:system",
+    "python-envs.pythonProjects": []
+}

--- a/service/routes.py
+++ b/service/routes.py
@@ -22,8 +22,9 @@ and Delete YourResourceModel
 """
 
 import os
-from flask import jsonify
+from flask import jsonify, abort
 from flask import current_app as app  # Import Flask application
+from service.models import Recommendation
 from service.common import status  # HTTP Status Codes
 
 
@@ -102,3 +103,19 @@ def health():
 ######################################################################
 #  R E S T   A P I   E N D P O I N T S
 ######################################################################
+
+
+######################################################################
+# READ A RECOMMENDATION
+######################################################################
+@app.route(f"{BASE_PATH}/<int:recommendation_id>", methods=["GET"])
+def get_recommendation(recommendation_id):
+    """Retrieve a single Recommendation by its id"""
+    app.logger.info("GET %s/%s", BASE_PATH, recommendation_id)
+    recommendation = Recommendation.find(recommendation_id)
+    if not recommendation:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Recommendation with id '{recommendation_id}' was not found.",
+        )
+    return jsonify(recommendation.serialize()), status.HTTP_200_OK

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -25,6 +25,7 @@ import logging
 from unittest import TestCase
 from unittest.mock import patch
 from service.common import status
+from tests.factories import RecommendationFactory
 
 
 ######################################################################
@@ -164,4 +165,27 @@ class TestYourResourceService(TestCase):
         self.assertTrue(resp.content_type.startswith("application/json"))
         data = resp.get_json()
         self.assertEqual(data["error"], "Method not Allowed")
+        self.assertIn("message", data)
+
+    def test_get_recommendation(self):
+        """It should read a single recommendation"""
+        client = self._create_test_client()
+        # Create a recommendation in the database
+        rec = RecommendationFactory()
+        rec.create()
+        resp = client.get(f"/api/recommendations/v1/{rec.id}")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(data["id"], rec.id)
+        self.assertEqual(data["product_id"], rec.product_id)
+        self.assertEqual(data["recommended_product_id"], rec.recommended_product_id)
+        self.assertEqual(data["recommendation_type"], rec.recommendation_type)
+
+    def test_get_recommendation_not_found(self):
+        """It should return 404 for a recommendation that doesn't exist"""
+        client = self._create_test_client()
+        resp = client.get("/api/recommendations/v1/0")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertTrue(resp.content_type.startswith("application/json"))
+        data = resp.get_json()
         self.assertIn("message", data)


### PR DESCRIPTION
## Summary
- Added `GET /api/recommendations/v1/<id>` endpoint that returns a recommendation by its ID
- Returns 200 with the full recommendation record (id, product_id, recommended_product_id, recommendation_type, score)
- Returns 404 with a JSON error message when the ID doesn't exist
- Added tests for both happy path and sad path scenarios

## Test plan
- [x] `test_get_recommendation`: verifies 200 response with correct fields for an existing recommendation
- [x] `test_get_recommendation_not_found`: verifies 404 JSON response for a non-existent ID
- [x] All tests pass with 95%+ coverage

Closes #3