### PR TITLE
Add DELETE endpoint to remove a recommendation by ID

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -22,8 +22,9 @@ and Delete YourResourceModel
 """
 
 import os
-from flask import jsonify
+from flask import jsonify, abort
 from flask import current_app as app  # Import Flask application
+from service.models import Recommendation
 from service.common import status  # HTTP Status Codes
 
 
@@ -102,3 +103,20 @@ def health():
 ######################################################################
 #  R E S T   A P I   E N D P O I N T S
 ######################################################################
+
+
+######################################################################
+# DELETE A RECOMMENDATION
+######################################################################
+@app.route(f"{BASE_PATH}/<int:recommendation_id>", methods=["DELETE"])
+def delete_recommendation(recommendation_id):
+    """Delete a Recommendation by its id"""
+    app.logger.info("DELETE %s/%s", BASE_PATH, recommendation_id)
+    recommendation = Recommendation.find(recommendation_id)
+    if not recommendation:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Recommendation with id '{recommendation_id}' was not found.",
+        )
+    recommendation.delete()
+    return "", status.HTTP_204_NO_CONTENT

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -24,7 +24,14 @@ import sys
 import logging
 from unittest import TestCase
 from unittest.mock import patch
+from wsgi import app
+from service.models import Recommendation, db
 from service.common import status
+from tests.factories import RecommendationFactory
+
+DATABASE_URI = os.getenv(
+    "DATABASE_URI", "postgresql+psycopg://postgres:postgres@localhost:5432/testdb"
+)
 
 
 ######################################################################
@@ -33,6 +40,29 @@ from service.common import status
 # pylint: disable=too-many-public-methods
 class TestYourResourceService(TestCase):
     """REST API Server Tests"""
+
+    @classmethod
+    def setUpClass(cls):
+        """This runs once before the entire test suite"""
+        app.config["TESTING"] = True
+        app.config["DEBUG"] = False
+        app.config["SQLALCHEMY_DATABASE_URI"] = DATABASE_URI
+        app.logger.setLevel(logging.CRITICAL)
+        app.app_context().push()
+
+    @classmethod
+    def tearDownClass(cls):
+        """This runs once after the entire test suite"""
+        db.session.close()
+
+    def setUp(self):
+        """This runs before each test"""
+        db.session.query(Recommendation).delete()
+        db.session.commit()
+
+    def tearDown(self):
+        """This runs after each test"""
+        db.session.remove()
 
     def _create_test_client(self, env_overrides=None):
         """Create an app client with temporary ENV/API_PREFIX/API_VERSION values"""
@@ -164,4 +194,25 @@ class TestYourResourceService(TestCase):
         self.assertTrue(resp.content_type.startswith("application/json"))
         data = resp.get_json()
         self.assertEqual(data["error"], "Method not Allowed")
+        self.assertIn("message", data)
+
+    def test_delete_recommendation(self):
+        """It should delete a recommendation"""
+        rec = RecommendationFactory()
+        rec.create()
+        # Verify it exists
+        self.assertIsNotNone(Recommendation.find(rec.id))
+        # Delete it
+        resp = app.test_client().delete(f"/api/recommendations/v1/{rec.id}")
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(resp.get_data(as_text=True), "")
+        # Verify it's gone
+        self.assertIsNone(Recommendation.find(rec.id))
+
+    def test_delete_recommendation_not_found(self):
+        """It should return 404 when deleting a non-existent recommendation"""
+        resp = app.test_client().delete("/api/recommendations/v1/0")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertTrue(resp.content_type.startswith("application/json"))
+        data = resp.get_json()
         self.assertIn("message", data)


### PR DESCRIPTION
## Summary
- Added `DELETE /api/recommendations/v1/<id>` endpoint that removes a recommendation by its ID
- Returns 204 (No Content) on successful deletion
- Returns 404 with JSON error message when the ID doesn't exist
- Added database setup/teardown lifecycle methods (`setUpClass`, `setUp`, `tearDown`, `tearDownClass`) to the route test class for reliable test isolation
- Added tests for both happy path and sad path scenarios

## Test plan
- `test_delete_recommendation`: creates a recommendation, sends DELETE, verifies 204 response with empty body, confirms record is removed from DB
- `test_delete_recommendation_not_found`: verifies 404 JSON response for a non-existent ID
- All tests pass with 95%+ coverage

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)